### PR TITLE
Updated Mining Skill (plus updated dependency)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,10 @@
 
     <!-- Paper API -->
     <dependency>
-      <groupId>com.destroystokyo.paper</groupId>
+      <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.16.5-R0.1-SNAPSHOT</version>
+      <version>1.17.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
-      <optional>true</optional>
     </dependency>
 
     <!-- Lombok -->

--- a/src/main/java/com/cavetale/skills/Mining.java
+++ b/src/main/java/com/cavetale/skills/Mining.java
@@ -25,6 +25,8 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
+import jdk.javadoc.internal.doclets.toolkit.util.DeprecatedAPIListBuilder.DeprElementKind;
+
 final class Mining {
     final SkillsPlugin plugin;
     final EnumMap<Material, Reward> rewards = new EnumMap<>(Material.class);

--- a/src/main/java/com/cavetale/skills/Mining.java
+++ b/src/main/java/com/cavetale/skills/Mining.java
@@ -39,7 +39,11 @@ final class Mining {
 
         boolean dropSelf() {
             switch (material) {
+            case DEEPSLATE_IRON_ORE:
             case IRON_ORE:
+            case DEEPSLATE_COPPER_ORE:
+            case COPPER_ORE:
+            case DEEPSLATE_GOLD_ORE:
             case GOLD_ORE:
                 return true;
             default: return false;
@@ -55,21 +59,40 @@ final class Mining {
         this.plugin = plugin;
         // exp values are maxima according to the wiki
         reward(Material.DIAMOND_ORE, 10, 7, Material.DIAMOND, 1);
+        reward(Material.DEEPSLATE_DIAMOND_ORE, 10, 7, Material.DIAMOND, 1);
+
         reward(Material.EMERALD_ORE, 10, 7, Material.EMERALD, 1);
+        reward(Material.DEEPSLATE_EMERALD_ORE, 10, 7, Material.EMERALD, 1);
+
         reward(Material.IRON_ORE, 3, 3, Material.IRON_NUGGET, 9);
+        reward(Material.DEEPSLATE_IRON_ORE, 3, 3, Material.IRON_NUGGET, 9);
+
+        reward(Material.COPPER_ORE, 3, 3, null, 0);
+        reward(Material.DEEPSLATE_COPPER_ORE, 3, 3, null, 0);
+
         reward(Material.GOLD_ORE, 5, 3, Material.GOLD_NUGGET, 9);
+        reward(Material.DEEPSLATE_GOLD_ORE, 5, 3, Material.GOLD_NUGGET, 9);
         reward(Material.NETHER_GOLD_ORE, 5, 3, Material.GOLD_NUGGET, 9);
         reward(Material.GILDED_BLACKSTONE, 5, 3, null, 0);
+
         reward(Material.COAL_ORE, 1, 2, Material.COAL, 1);
+        reward(Material.DEEPSLATE_COAL_ORE, 1, 2, Material.COAL, 1);
+
         reward(Material.LAPIS_ORE, 1, 5, Material.LAPIS_LAZULI, 6); // 4-8
+        reward(Material.DEEPSLATE_LAPIS_ORE, 1, 5, Material.LAPIS_LAZULI, 6);
+
         reward(Material.NETHER_QUARTZ_ORE, 1, 5, Material.QUARTZ, 1);
+
         reward(Material.REDSTONE_ORE, 1, 5, Material.REDSTONE, 5); // 4-5
+        reward(Material.DEEPSLATE_REDSTONE_ORE, 1, 5, Material.REDSTONE, 5);
+
         reward(Material.ANCIENT_DEBRIS, 20, 10, null, 0); // 4-5
     }
 
     static boolean stone(@NonNull Block block) {
         switch (block.getType()) {
         case STONE:
+        case DEEPSLATE:
         case DIORITE:
         case ANDESITE:
         case GRANITE:

--- a/src/main/java/com/cavetale/skills/Mining.java
+++ b/src/main/java/com/cavetale/skills/Mining.java
@@ -93,6 +93,7 @@ final class Mining {
         switch (block.getType()) {
         case STONE:
         case DEEPSLATE:
+        case TUFF:
         case DIORITE:
         case ANDESITE:
         case GRANITE:

--- a/src/main/java/com/cavetale/skills/Mining.java
+++ b/src/main/java/com/cavetale/skills/Mining.java
@@ -25,8 +25,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
-import jdk.javadoc.internal.doclets.toolkit.util.DeprecatedAPIListBuilder.DeprElementKind;
-
 final class Mining {
     final SkillsPlugin plugin;
     final EnumMap<Material, Reward> rewards = new EnumMap<>(Material.class);


### PR DESCRIPTION
I updated Mining.java to have all the deepslate ores affected by vein miner/silk stripping (minus copper, which won't do anything when stripped) and added deepslate to be affected by strip mining. I gave copper ore the same sp and exp values as iron, since the ores seem pretty similar to me.

I also updated the PaperMC dependency to 1.17 in the pom.xml file by using the provided dependency formatting from the papermc documentation page here: https://papermc.io/using-the-api

I couldn't fully test if it worked on my private server, but it 100% compiles and attempts to run until it hits SQL :)