### PR TITLE
Initial combat expansion

### DIFF
--- a/src/main/java/com/cavetale/skills/session/CombatSession.java
+++ b/src/main/java/com/cavetale/skills/session/CombatSession.java
@@ -10,6 +10,9 @@ public final class CombatSession extends SkillSession {
     @Setter protected boolean poisonFreebie = false;
     /** Cooldown in Epoch Millis. */
     @Setter protected long godModeDuration = 0;
+    /**  Impaler's target and current impale stacks. */
+    @Setter protected int impalerTargetId = 0;
+    @Setter protected int impalerStack = 0;
 
     protected CombatSession(final Session session, final SkillType skillType) {
         super(session, skillType);

--- a/src/main/java/com/cavetale/skills/skill/SkillType.java
+++ b/src/main/java/com/cavetale/skills/skill/SkillType.java
@@ -41,7 +41,7 @@ public enum SkillType {
     }
 
     // This tag is used for advancements and GUIs.
-    public final record SkillTag(String title, TextColor color, BossBar.Color bossBarColor,
+    public record SkillTag(String title, TextColor color, BossBar.Color bossBarColor,
                                  String description,
                                  Material icon, String background,
                                  String... moreText) {

--- a/src/main/java/com/cavetale/skills/skill/TalentType.java
+++ b/src/main/java/com/cavetale/skills/skill/TalentType.java
@@ -27,9 +27,14 @@ public enum TalentType {
     // Combat
     SEARING(TalentTag.SEARING, SkillType.COMBAT, null),
     PYROMANIAC(TalentTag.PYROMANIAC, SkillType.COMBAT, SEARING),
-    DENIAL(TalentTag.DENIAL, SkillType.COMBAT, TalentType.PYROMANIAC), // +slow?
+    DENIAL(TalentTag.DENIAL, SkillType.COMBAT, null), // +slow?
     GOD_MODE(TalentTag.GOD_MODE, SkillType.COMBAT, TalentType.DENIAL),
-    COMBAT_ARCHER_ZONE(TalentTag.COMBAT_ARCHER_ZONE, SkillType.COMBAT, TalentType.PYROMANIAC);
+    ARCHER_ZONE(TalentTag.ARCHER_ZONE, SkillType.COMBAT, null),
+    IRON_AGE(TalentTag.IRON_AGE, SkillType.COMBAT, null),
+    EXECUTIONER(TalentTag.EXECUTIONER, SkillType.COMBAT, TalentType.IRON_AGE),
+    IMPALER(TalentTag.IMPALER, SkillType.COMBAT, TalentType.IRON_AGE),
+    TOXICIST(TalentTag.TOXICIST, SkillType.COMBAT, TalentType.DENIAL),
+    TOXIC_FUROR(TalentTag.TOXIC_FUROR, SkillType.COMBAT, TalentType.TOXICIST);
 
     public final TalentTag tag;
     public final String key;
@@ -76,7 +81,7 @@ public enum TalentType {
         this.talent = newTalent;
     }
 
-    public static record TalentTag(String title, Material icon, int x, int y,
+    public record TalentTag(String title, Material icon, int x, int y,
                                    String legacyDescription, String... legacyMoreText) {
         public static final TalentTag FARM_GROWSTICK_RADIUS = new
             TalentTag("Spoutcraft",
@@ -181,20 +186,41 @@ public enum TalentType {
                       + " unaffected by Fortune: Iron and gold.");
 
         public static final TalentTag SEARING = new
-            TalentTag("Searing", Material.SOUL_CAMPFIRE, 5, 3, "");
+            TalentTag("Searing", Material.SOUL_CAMPFIRE, 4, 4, "Monsters set on fire deal -30% melee damage");
 
         public static final TalentTag PYROMANIAC = new
-            TalentTag("Pyromaniac", Material.CAMPFIRE, 6, 3, "");
+            TalentTag("Pyromaniac", Material.CAMPFIRE, 4, 5, "Monsters set on fire take +30% damage");
 
         public static final TalentTag DENIAL = new
-            TalentTag("Denial", Material.BARRIER, 5, 2, "");
+            TalentTag("Denial", Material.BARRIER, 5, 3, "Knockback denies mob spells, projectiles, poison");
+
+        public static final TalentTag TOXICIST = new
+            TalentTag("Toxicist", Material.POISONOUS_POTATO, 6, 2, "Bane of Arthropods deals extra damage against poisoned mobs");
+
+        public static final TalentTag TOXIC_FUROR = new
+            TalentTag("Toxic Furor", Material.EXPERIENCE_BOTTLE, 7, 2, "Deal extra damage while affected by Poison, Wither or Nausea");
 
         public static final TalentTag GOD_MODE = new
-            TalentTag("God Mode", Material.TOTEM_OF_UNDYING, 7, 2, "");
+            TalentTag("God Mode", Material.TOTEM_OF_UNDYING, 6, 3, "");
 
-        public static final TalentTag COMBAT_ARCHER_ZONE = new
+        public static final TalentTag ARCHER_ZONE = new
             TalentTag("In The Zone",
-                      Material.SPECTRAL_ARROW, 5, 4,
+                      Material.SPECTRAL_ARROW, 4, 2,
                       "Ranged kills give 5 seconds of double damage to ranged attacks");
+
+        public static final TalentTag IRON_AGE = new
+            TalentTag("Iron Age",
+                      Material.IRON_SWORD, 3, 3,
+                      "Iron weapons deal +1 base damage");
+
+        public static final TalentTag EXECUTIONER = new
+            TalentTag("Executioner",
+                      Material.IRON_AXE, 2, 3,
+                      "Fully charged axe attacks kill mobs under 10% health");
+
+        public static final TalentTag IMPALER = new
+            TalentTag("Impaler",
+                      Material.TRIDENT, 2, 2,
+                      "Consecutive hits with a fully charged Impaling weapon against the same foe deal increasing damage");
     }
 }

--- a/src/main/java/com/cavetale/skills/skill/combat/ArcherZoneTalent.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/ArcherZoneTalent.java
@@ -19,7 +19,7 @@ public final class ArcherZoneTalent extends Talent {
     protected final CombatSkill combatSkill;
 
     protected ArcherZoneTalent(final SkillsPlugin plugin, final CombatSkill combatSkill) {
-        super(plugin, TalentType.COMBAT_ARCHER_ZONE);
+        super(plugin, TalentType.ARCHER_ZONE);
         this.combatSkill = combatSkill;
     }
 

--- a/src/main/java/com/cavetale/skills/skill/combat/CombatSkill.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/CombatSkill.java
@@ -29,6 +29,11 @@ public final class CombatSkill extends Skill {
     public final DenialTalent denialTalent;
     public final GodModeTalent godModeTalent;
     public final ArcherZoneTalent archerZoneTalent;
+    public final IronAgeTalent ironAgeTalent;
+    public final ExecutionerTalent executionerTalent;
+    public final ImpalerTalent impalerTalent;
+    public final ToxicistTalent toxicistTalent;
+    public final ToxicFurorTalent toxicFurorTalent;
 
     protected static final long CHUNK_KILL_COOLDOWN = Duration.ofMinutes(5).toMillis();
 
@@ -41,6 +46,11 @@ public final class CombatSkill extends Skill {
         this.denialTalent = new DenialTalent(plugin, this);
         this.godModeTalent = new GodModeTalent(plugin, this);
         this.archerZoneTalent = new ArcherZoneTalent(plugin, this);
+        this.ironAgeTalent = new IronAgeTalent(plugin, this);
+        this.executionerTalent = new ExecutionerTalent(plugin, this);
+        this.impalerTalent = new ImpalerTalent(plugin, this);
+        this.toxicistTalent = new ToxicistTalent(plugin, this);
+        this.toxicFurorTalent = new ToxicFurorTalent(plugin, this);
     }
 
     @Override
@@ -61,6 +71,11 @@ public final class CombatSkill extends Skill {
         denialTalent.onPlayerDamageMob(player, mob, item, proj, event);
         denialTalent.onPlayerDamageMob(player, mob, item, proj, event);
         archerZoneTalent.onPlayerDamageMob(player, mob, item, proj, event);
+        ironAgeTalent.onPlayerDamageMob(player, mob, item, proj, event);
+        executionerTalent.onPlayerDamageMob(player, mob, item, proj, event);
+        impalerTalent.onPlayerDamageMob(player, mob, item, proj, event);
+        toxicistTalent.onPlayerDamageMob(player, mob, item, proj, event);
+        toxicFurorTalent.onPlayerDamageMob(player, mob, item, proj, event);
     }
 
     /**

--- a/src/main/java/com/cavetale/skills/skill/combat/ExecutionerTalent.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/ExecutionerTalent.java
@@ -1,0 +1,36 @@
+package com.cavetale.skills.skill.combat;
+
+import com.cavetale.skills.SkillsPlugin;
+import com.cavetale.skills.skill.Talent;
+import com.cavetale.skills.skill.TalentType;
+import com.destroystokyo.paper.MaterialTags;
+import java.util.List;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class ExecutionerTalent extends Talent {
+    protected final CombatSkill combatSkill;
+
+    protected ExecutionerTalent(final SkillsPlugin plugin, final CombatSkill combatSkill) {
+        super(plugin, TalentType.EXECUTIONER);
+        this.combatSkill = combatSkill;
+        this.description = "Fully charged axe attacks kill mobs under 10% health";
+        this.infoPages = List.of();
+    }
+
+    @Override protected void enable() { }
+
+    protected void onPlayerDamageMob(Player player, Mob mob, ItemStack item, Projectile projectile,
+                                     EntityDamageByEntityEvent event) {
+        if (projectile != null) return;
+        if (!isPlayerEnabled(player)) return;
+        if (item == null || !MaterialTags.AXES.isTagged(item.getType()) || (mob.getHealth() / mob.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()) > 0.1
+|| player.getAttackCooldown() != 1.0) return;
+        event.setDamage(event.getDamage() + mob.getHealth());
+        mob.setHealth(1);
+    }
+}

--- a/src/main/java/com/cavetale/skills/skill/combat/ImpalerTalent.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/ImpalerTalent.java
@@ -1,0 +1,42 @@
+package com.cavetale.skills.skill.combat;
+
+import com.cavetale.skills.SkillsPlugin;
+import com.cavetale.skills.session.Session;
+import com.cavetale.skills.skill.Talent;
+import com.cavetale.skills.skill.TalentType;
+import java.util.List;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
+
+public final class ImpalerTalent extends Talent {
+    protected final CombatSkill combatSkill;
+
+    protected ImpalerTalent(final SkillsPlugin plugin, final CombatSkill combatSkill) {
+        super(plugin, TalentType.IMPALER);
+        this.combatSkill = combatSkill;
+        this.description = "Consecutive hits with a fully charged Impaling weapon against the same foe deal increasing damage";
+        this.infoPages = List.of();
+    }
+
+    @Override protected void enable() { }
+
+    protected void onPlayerDamageMob(Player player, Mob mob, ItemStack item, Projectile projectile,
+                                     EntityDamageByEntityEvent event) {
+        if (!isPlayerEnabled(player)) return;
+        if (item == null || item.getType() == Material.ENCHANTED_BOOK || item.getEnchantmentLevel(Enchantment.IMPALING) <= 0
+                        || player.getAttackCooldown() != 1.0) return;
+        Session session = plugin.sessions.of(player);
+        if (mob.getEntityId() != session.combat.getImpalerTargetId()) {
+            session.combat.setImpalerTargetId(mob.getEntityId());
+            session.combat.setImpalerStack(0);
+        } else {
+            event.setDamage(event.getDamage() + session.combat.getImpalerStack());
+            if (session.combat.getImpalerStack() < 6) session.combat.setImpalerStack(session.combat.getImpalerStack() + 1);
+        }
+    }
+}

--- a/src/main/java/com/cavetale/skills/skill/combat/IronAgeTalent.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/IronAgeTalent.java
@@ -1,0 +1,33 @@
+package com.cavetale.skills.skill.combat;
+
+import com.cavetale.skills.SkillsPlugin;
+import com.cavetale.skills.skill.Talent;
+import com.cavetale.skills.skill.TalentType;
+import java.util.List;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
+
+public final class IronAgeTalent extends Talent {
+    protected final CombatSkill combatSkill;
+
+    protected IronAgeTalent(final SkillsPlugin plugin, final CombatSkill combatSkill) {
+        super(plugin, TalentType.IRON_AGE);
+        this.combatSkill = combatSkill;
+        this.description = "Iron weapons deal +1 base damage";
+        this.infoPages = List.of();
+    }
+
+    @Override protected void enable() { }
+
+    protected void onPlayerDamageMob(Player player, Mob mob, ItemStack item, Projectile projectile,
+                                     EntityDamageByEntityEvent event) {
+        if (projectile != null) return;
+        if (!isPlayerEnabled(player)) return;
+        if (item.getType() != Material.IRON_SWORD && item.getType() != Material.IRON_AXE) return; // Check for dealing damage with an iron weapon
+        event.setDamage(event.getDamage() + 1); // +1 base damage before any damage reduction
+    }
+}

--- a/src/main/java/com/cavetale/skills/skill/combat/ToxicFurorTalent.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/ToxicFurorTalent.java
@@ -1,0 +1,38 @@
+package com.cavetale.skills.skill.combat;
+
+import com.cavetale.skills.SkillsPlugin;
+import com.cavetale.skills.skill.Talent;
+import com.cavetale.skills.skill.TalentType;
+import java.util.List;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffectType;
+
+public final class ToxicFurorTalent extends Talent {
+    protected final CombatSkill combatSkill;
+
+    protected ToxicFurorTalent(final SkillsPlugin plugin, final CombatSkill combatSkill) {
+        super(plugin, TalentType.TOXIC_FUROR);
+        this.combatSkill = combatSkill;
+        this.description = "Deal extra damage while affected by Poison, Wither or Nausea";
+        this.infoPages = List.of();
+    }
+
+    @Override protected void enable() { }
+
+    protected void onPlayerDamageMob(Player player, Mob mob, ItemStack item, Projectile projectile,
+                                     EntityDamageByEntityEvent event) {
+        if (!isPlayerEnabled(player)) return;
+        if (item == null || player.getAttackCooldown() != 1.0) return;
+        if (!player.hasPotionEffect(PotionEffectType.POISON) && !player.hasPotionEffect(PotionEffectType.WITHER)
+&& !player.hasPotionEffect(PotionEffectType.CONFUSION)) return;
+        int extraDamage = 0;
+        if (player.hasPotionEffect(PotionEffectType.POISON)) extraDamage += player.getPotionEffect(PotionEffectType.POISON).getAmplifier();
+        if (player.hasPotionEffect(PotionEffectType.WITHER)) extraDamage += player.getPotionEffect(PotionEffectType.WITHER).getAmplifier();
+        if (player.hasPotionEffect(PotionEffectType.CONFUSION)) extraDamage += player.getPotionEffect(PotionEffectType.CONFUSION).getAmplifier();
+        event.setDamage(event.getDamage() + extraDamage);
+    }
+}

--- a/src/main/java/com/cavetale/skills/skill/combat/ToxicistTalent.java
+++ b/src/main/java/com/cavetale/skills/skill/combat/ToxicistTalent.java
@@ -1,0 +1,36 @@
+package com.cavetale.skills.skill.combat;
+
+import com.cavetale.skills.SkillsPlugin;
+import com.cavetale.skills.skill.Talent;
+import com.cavetale.skills.skill.TalentType;
+import java.util.List;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
+import org.bukkit.potion.PotionEffectType;
+
+public final class ToxicistTalent extends Talent {
+    protected final CombatSkill combatSkill;
+
+    protected ToxicistTalent(final SkillsPlugin plugin, final CombatSkill combatSkill) {
+        super(plugin, TalentType.TOXICIST);
+        this.combatSkill = combatSkill;
+        this.description = "Bane of Arthropods deals extra damage against poisoned mobs";
+        this.infoPages = List.of();
+    }
+
+    @Override protected void enable() { }
+
+    protected void onPlayerDamageMob(Player player, Mob mob, ItemStack item, Projectile projectile,
+                                     EntityDamageByEntityEvent event) {
+        if (projectile != null) return;
+        if (!isPlayerEnabled(player)) return;
+        if (item == null || item.getType() == Material.ENCHANTED_BOOK || item.getEnchantmentLevel(Enchantment.DAMAGE_ARTHROPODS) <= 0
+|| player.getAttackCooldown() != 1.0 || !mob.hasPotionEffect(PotionEffectType.POISON)) return;
+        event.setDamage(event.getDamage() + (item.getEnchantmentLevel(Enchantment.DAMAGE_ARTHROPODS) + 1) / 2);
+    }
+}


### PR DESCRIPTION
Added talents:
- Iron Age
- Impaler
- Executioner
- Toxicist
- Toxic Furor
Changed talent dependencies
Reorganized icons in the Combat Talent GUI
Fire talents nerfed: 50% -> 30%
Remedied some checkstyle complaints about static and final being redundant in some places
Changed COMBAT_ARCHER_ZONE -> ARCHER_ZONE because of talent name length limits in the database